### PR TITLE
Modernize plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.7</version>
+        <version>4.37</version>
         <relativePath />
     </parent>
 
@@ -42,9 +42,9 @@
     </pluginRepositories>
 
     <properties>
-        <jenkins.version>2.235.1</jenkins.version>
+        <jenkins.version>2.289.1</jenkins.version>
         <java.level>8</java.level>
-        <jcasc.version>1.35</jcasc.version>
+        <jcasc.version>1.55.1</jcasc.version>
     </properties>
 
     <dependencies>

--- a/src/main/java/org/jenkinsci/plugins/secure_requester_whitelist/Whitelist.java
+++ b/src/main/java/org/jenkinsci/plugins/secure_requester_whitelist/Whitelist.java
@@ -24,6 +24,7 @@
 
 package org.jenkinsci.plugins.secure_requester_whitelist;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import jenkins.model.GlobalConfiguration;
 import jenkins.model.GlobalConfigurationCategory;
@@ -33,8 +34,6 @@ import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.StaplerRequest;
-
-import javax.annotation.Nonnull;
 
 @Extension
 @Symbol("secureRequesterWhitelist")
@@ -53,8 +52,7 @@ public class Whitelist extends GlobalConfiguration {
         load();
     }
 
-    @Nonnull @Override
-    public GlobalConfigurationCategory getCategory() {
+    @NonNull @Override public GlobalConfigurationCategory getCategory() {
         return GlobalConfigurationCategory.get(GlobalConfigurationCategory.Security.class);
     }
 


### PR DESCRIPTION
* Newest parent POM (includes change to nullability annotations)
* [Drop an implied dependency by going with 2.289.1](https://github.com/jenkinsci/jenkins/blob/77af1bde9466f4265b1e58b078f83033b1d50ecf/core/src/main/resources/jenkins/split-plugins.txt#L36)
* Update JCasC dependency to shut up Dependabot

This way there's also some value to users when releasing #9 😄 