### PR TITLE
Bump parent from 4.37 to 4.47 to fix flaky SecureRequesterImplTest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.37</version>
+        <version>4.47</version>
         <relativePath />
     </parent>
 


### PR DESCRIPTION
4.47 got the fixed jenkins-test-harness to remove flakiness in SecureRequesterImplTest
