### PR TITLE
Clean up terminology

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <artifactId>secure-requester-whitelist</artifactId>
     <version>1.8-SNAPSHOT</version>
     <packaging>hpi</packaging>
-    <name>Secure Requester Whitelist Plugin</name>
+    <name>Secure Requester Allowlist Plugin</name>
     <description>Allows an administrator to specify sites trusted to make JSONP or primitive-XPath REST API requests.</description>
     <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
     <licenses>

--- a/src/main/java/org/jenkinsci/plugins/secure_requester_whitelist/Whitelist.java
+++ b/src/main/java/org/jenkinsci/plugins/secure_requester_whitelist/Whitelist.java
@@ -36,7 +36,7 @@ import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.StaplerRequest;
 
 @Extension
-@Symbol("secureRequesterWhitelist")
+@Symbol({"secureRequesterAllowlist", "secureRequesterWhitelist"})
 public class Whitelist extends GlobalConfiguration {
 
     public static Whitelist get() {

--- a/src/main/resources/org/jenkinsci/plugins/secure_requester_whitelist/Whitelist/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/secure_requester_whitelist/Whitelist/config.jelly
@@ -25,7 +25,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
-    <f:section title="${%Authorize JSONP or primitive XPath requests by whitelist}">
+    <f:section title="${%Authorize JSONP or primitive XPath requests by allowlist}">
         <f:entry field="allowNoReferer" title="${%Allow requests without Referer}">
             <f:checkbox/>
         </f:entry>

--- a/src/test/java/org/jenkinsci/plugins/secure_requester_whitelist/LegacySymbolCasCTest.java
+++ b/src/test/java/org/jenkinsci/plugins/secure_requester_whitelist/LegacySymbolCasCTest.java
@@ -1,0 +1,27 @@
+package org.jenkinsci.plugins.secure_requester_whitelist;
+
+import io.jenkins.plugins.casc.misc.RoundTripAbstractTest;
+import org.jvnet.hudson.test.RestartableJenkinsRule;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class LegacySymbolCasCTest extends RoundTripAbstractTest {
+
+    @Override
+    protected String configResource() {
+        return "LegacySymbol.yml";
+    }
+
+    @Override
+    protected void assertConfiguredAsExpected(RestartableJenkinsRule restartableJenkinsRule, String s) {
+        final Whitelist whitelist = Whitelist.get();
+        assertTrue(whitelist.isAllowNoReferer());
+        assertEquals("acme.org jenkins.io", whitelist.getDomains());
+    }
+
+    @Override
+    protected String stringInLogExpected() {
+        return "Setting org.jenkinsci.plugins.secure_requester_whitelist.Whitelist";
+    }
+}

--- a/src/test/resources/org/jenkinsci/plugins/secure_requester_whitelist/CasCTest.yml
+++ b/src/test/resources/org/jenkinsci/plugins/secure_requester_whitelist/CasCTest.yml
@@ -1,4 +1,4 @@
 security:
-  secureRequesterWhitelist:
+  secureRequesterAllowlist:
     allowNoReferer: true
     domains: "acme.org jenkins.io"

--- a/src/test/resources/org/jenkinsci/plugins/secure_requester_whitelist/LegacySymbol.yml
+++ b/src/test/resources/org/jenkinsci/plugins/secure_requester_whitelist/LegacySymbol.yml
@@ -1,0 +1,4 @@
+security:
+  secureRequesterWhitelist:
+    allowNoReferer: true
+    domains: "acme.org jenkins.io"


### PR DESCRIPTION
The new test unfortunately fails with

```
java.lang.NullPointerException
	at io.jenkins.plugins.casc.ConfigurationAsCode.lambda$collectProblems$0(ConfigurationAsCode.java:262)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
	at java.base/java.util.HashMap$EntrySpliterator.forEachRemaining(HashMap.java:1764)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:497)
	at io.jenkins.plugins.casc.ConfigurationAsCode.collectProblems(ConfigurationAsCode.java:263)
	at io.jenkins.plugins.casc.ConfigurationAsCode.doCheckNewSource(ConfigurationAsCode.java:246)
```
